### PR TITLE
prevent negative Hourly Rate and Operation Time using non_negative property

### DIFF
--- a/erpnext/manufacturing/doctype/bom_operation/time_in_mins
+++ b/erpnext/manufacturing/doctype/bom_operation/time_in_mins
@@ -79,7 +79,8 @@
    "oldfieldname": "hour_rate",
    "oldfieldtype": "Currency",
    "options": "currency",
-   "precision": "2"
+   "precision": "2",
+    "non_negative": 1
   },
   {
    "columns": 1,
@@ -92,7 +93,8 @@
    "label": "Operation Time",
    "oldfieldname": "time_in_mins",
    "oldfieldtype": "Currency",
-   "reqd": 1
+   "reqd": 1,
+    "non_negative": 1
   },
   {
    "default": "0",


### PR DESCRIPTION
### Description
This PR fixes negative value validation for Hourly Rate and Operation Time in BOM Operations 
by using the `non_negative: 1` DocType field property instead of client-side JS validation.

### Related Issue
Fixes: #48662

### Steps to Test
1. Go to the BOM form.
2. Tick "With operations".
3. Add an operation with a negative Hourly Rate or Operation Time.
4. Save.

**Expected:** System should throw a validation error.  
**Before Fix:** Negative values were allowed.

### Checklist
- [x] I have tested these changes
- [x] I have commented my code where needed
- [x] The title of my pull request is clear and descriptive
